### PR TITLE
Implement eraser, dark mode and adjustable layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This project is a simple Java Swing application organized using the MVC pattern. It provides:
 
-- A top left control panel with 12 color buttons and a slider for line thickness.
-- A top right drawing canvas where you can drag to draw lines with the selected color and thickness.
+- A top left control panel with 12 color buttons, an eraser tool and sliders for line thickness and erase radius.
+- A top right drawing canvas where you can drag to draw lines with the selected color and thickness or erase with the eraser tool.
 - A bottom panel with a placeholder **Review** button.
+- A dark mode toggle that inverts colors on the canvas.
+- The control panel and canvas are separated by a resizable divider.
 
 ## Building and running
 

--- a/src/main/java/com/artwork/mvc/controller/DrawingController.java
+++ b/src/main/java/com/artwork/mvc/controller/DrawingController.java
@@ -24,18 +24,38 @@ public class DrawingController {
         view.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
-                lastPoint = e.getPoint();
+                if (model.isEraserMode()) {
+                    model.eraseAt(e.getPoint());
+                    view.setEraserPosition(e.getPoint());
+                    view.repaint();
+                } else {
+                    lastPoint = e.getPoint();
+                }
             }
         });
 
         view.addMouseMotionListener(new MouseMotionAdapter() {
             @Override
             public void mouseDragged(MouseEvent e) {
-                Point newPoint = e.getPoint();
-                Line line = new Line(lastPoint, newPoint, model.getCurrentColor(), model.getStrokeWidth());
-                model.addLine(line);
-                lastPoint = newPoint;
-                view.repaint();
+                if (model.isEraserMode()) {
+                    model.eraseAt(e.getPoint());
+                    view.setEraserPosition(e.getPoint());
+                    view.repaint();
+                } else {
+                    Point newPoint = e.getPoint();
+                    Line line = new Line(lastPoint, newPoint, model.getCurrentColor(), model.getStrokeWidth());
+                    model.addLine(line);
+                    lastPoint = newPoint;
+                    view.repaint();
+                }
+            }
+
+            @Override
+            public void mouseMoved(MouseEvent e) {
+                if (model.isEraserMode()) {
+                    view.setEraserPosition(e.getPoint());
+                    view.repaint();
+                }
             }
         });
     }

--- a/src/main/java/com/artwork/mvc/model/DrawingModel.java
+++ b/src/main/java/com/artwork/mvc/model/DrawingModel.java
@@ -1,13 +1,20 @@
 package com.artwork.mvc.model;
 
 import java.awt.Color;
+import java.awt.Point;
+import java.awt.geom.Line2D;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 public class DrawingModel {
     private final List<Line> lines = new ArrayList<>();
     private Color currentColor = Color.BLACK;
     private int strokeWidth = 2;
+
+    private boolean eraserMode = false;
+    private int eraserRadius = 10;
+    private boolean darkMode = false;
 
     public void addLine(Line line) {
         lines.add(line);
@@ -35,5 +42,55 @@ public class DrawingModel {
 
     public void clear() {
         lines.clear();
+    }
+
+    public boolean isEraserMode() {
+        return eraserMode;
+    }
+
+    public void setEraserMode(boolean eraserMode) {
+        this.eraserMode = eraserMode;
+    }
+
+    public int getEraserRadius() {
+        return eraserRadius;
+    }
+
+    public void setEraserRadius(int eraserRadius) {
+        this.eraserRadius = eraserRadius;
+    }
+
+    public boolean isDarkMode() {
+        return darkMode;
+    }
+
+    public void toggleDarkMode() {
+        darkMode = !darkMode;
+        complementAllLines();
+        currentColor = complementColor(currentColor);
+    }
+
+    public void eraseAt(Point p) {
+        Iterator<Line> it = lines.iterator();
+        while (it.hasNext()) {
+            Line l = it.next();
+            double dist = Line2D.ptSegDist(l.getStart().x, l.getStart().y,
+                    l.getEnd().x, l.getEnd().y, p.x, p.y);
+            if (dist <= eraserRadius) {
+                it.remove();
+            }
+        }
+    }
+
+    private void complementAllLines() {
+        for (int i = 0; i < lines.size(); i++) {
+            Line l = lines.get(i);
+            lines.set(i, new Line(l.getStart(), l.getEnd(),
+                    complementColor(l.getColor()), l.getStrokeWidth()));
+        }
+    }
+
+    public static Color complementColor(Color c) {
+        return new Color(255 - c.getRed(), 255 - c.getGreen(), 255 - c.getBlue());
     }
 }

--- a/src/main/java/com/artwork/mvc/view/ControlPanel.java
+++ b/src/main/java/com/artwork/mvc/view/ControlPanel.java
@@ -1,6 +1,7 @@
 package com.artwork.mvc.view;
 
 import com.artwork.mvc.model.DrawingModel;
+import com.artwork.mvc.view.DrawingPanel;
 
 import javax.swing.*;
 import java.awt.*;
@@ -12,18 +13,62 @@ public class ControlPanel extends JPanel {
             Color.PINK, Color.YELLOW, Color.DARK_GRAY, Color.LIGHT_GRAY
     };
 
-    public ControlPanel(DrawingModel model) {
+    private final JButton[] colorButtons = new JButton[COLORS.length];
+
+    public ControlPanel(DrawingModel model, DrawingPanel drawingPanel) {
         setLayout(new FlowLayout(FlowLayout.LEFT));
-        for (Color color : COLORS) {
+
+        for (int i = 0; i < COLORS.length; i++) {
+            Color color = COLORS[i];
             JButton btn = new JButton();
             btn.setPreferredSize(new Dimension(20, 20));
             btn.setBackground(color);
-            btn.addActionListener(e -> model.setCurrentColor(color));
+            btn.setBorderPainted(false);
+            btn.setFocusPainted(false);
+            final int idx = i;
+            btn.addActionListener(e -> model.setCurrentColor(colorButtons[idx].getBackground()));
+            colorButtons[i] = btn;
             add(btn);
         }
+
+        JButton eraser = new JButton("E");
+        eraser.setFocusPainted(false);
+        eraser.addActionListener(e -> {
+            boolean enable = !model.isEraserMode();
+            model.setEraserMode(enable);
+            if (!enable) {
+                drawingPanel.setEraserPosition(null);
+                drawingPanel.repaint();
+            }
+        });
+        add(eraser);
+
+        JSlider eraserSlider = new JSlider(5, 50, model.getEraserRadius());
+        eraserSlider.addChangeListener(e -> model.setEraserRadius(eraserSlider.getValue()));
+        add(new JLabel("Erase Radius:"));
+        add(eraserSlider);
+
         JSlider slider = new JSlider(1, 10, model.getStrokeWidth());
         slider.addChangeListener(e -> model.setStrokeWidth(slider.getValue()));
         add(new JLabel("Thickness:"));
         add(slider);
+
+        JCheckBox dark = new JCheckBox("Dark");
+        dark.addActionListener(e -> {
+            model.toggleDarkMode();
+            updateButtonColors(model);
+            drawingPanel.setBackground(model.isDarkMode() ? Color.BLACK : Color.WHITE);
+            drawingPanel.repaint();
+        });
+        add(dark);
+
+        updateButtonColors(model);
+    }
+
+    private void updateButtonColors(DrawingModel model) {
+        for (int i = 0; i < COLORS.length; i++) {
+            Color base = COLORS[i];
+            colorButtons[i].setBackground(model.isDarkMode() ? DrawingModel.complementColor(base) : base);
+        }
     }
 }

--- a/src/main/java/com/artwork/mvc/view/DrawingPanel.java
+++ b/src/main/java/com/artwork/mvc/view/DrawingPanel.java
@@ -8,6 +8,7 @@ import java.awt.*;
 
 public class DrawingPanel extends JPanel {
     private final DrawingModel model;
+    private Point eraserPosition;
 
     public DrawingPanel(DrawingModel model) {
         this.model = model;
@@ -26,5 +27,14 @@ public class DrawingPanel extends JPanel {
             Point e = line.getEnd();
             g2.drawLine(s.x, s.y, e.x, e.y);
         }
+        if (model.isEraserMode() && eraserPosition != null) {
+            int r = model.getEraserRadius();
+            g2.setColor(model.isDarkMode() ? Color.WHITE : Color.BLACK);
+            g2.drawOval(eraserPosition.x - r, eraserPosition.y - r, r * 2, r * 2);
+        }
+    }
+
+    public void setEraserPosition(Point p) {
+        this.eraserPosition = p;
     }
 }

--- a/src/main/java/com/artwork/mvc/view/MainFrame.java
+++ b/src/main/java/com/artwork/mvc/view/MainFrame.java
@@ -15,15 +15,15 @@ public class MainFrame extends JFrame {
         DrawingPanel drawingPanel = new DrawingPanel(model);
         new DrawingController(model, drawingPanel);
 
-        ControlPanel controlPanel = new ControlPanel(model);
+        ControlPanel controlPanel = new ControlPanel(model, drawingPanel);
         ReviewPanel reviewPanel = new ReviewPanel();
 
-        JPanel topPanel = new JPanel(new BorderLayout());
-        topPanel.add(controlPanel, BorderLayout.WEST);
-        topPanel.add(drawingPanel, BorderLayout.CENTER);
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, controlPanel, drawingPanel);
+        splitPane.setResizeWeight(0);
+        splitPane.setDividerLocation(150);
 
         getContentPane().setLayout(new BorderLayout());
-        add(topPanel, BorderLayout.CENTER);
+        add(splitPane, BorderLayout.CENTER);
         add(reviewPanel, BorderLayout.SOUTH);
 
         pack();


### PR DESCRIPTION
## Summary
- add eraser support with adjustable radius
- implement dark mode that complements colors
- make color buttons borderless and update in dark mode
- show eraser cursor when erasing
- use split pane so canvas and controls are resizable
- document new features

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6881dfe69ebc8325bdad4518619e5795