### PR TITLE
Fix missing color icons and adjust layout

### DIFF
--- a/src/main/java/com/artwork/mvc/view/ColorIcon.java
+++ b/src/main/java/com/artwork/mvc/view/ColorIcon.java
@@ -1,0 +1,35 @@
+package com.artwork.mvc.view;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Simple square icon painted with the given color.
+ */
+public class ColorIcon implements Icon {
+    private final Color color;
+    private final int size;
+
+    public ColorIcon(Color color, int size) {
+        this.color = color;
+        this.size = size;
+    }
+
+    @Override
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+        g.setColor(color);
+        g.fillRect(x, y, size, size);
+        g.setColor(Color.BLACK);
+        g.drawRect(x, y, size - 1, size - 1);
+    }
+
+    @Override
+    public int getIconWidth() {
+        return size;
+    }
+
+    @Override
+    public int getIconHeight() {
+        return size;
+    }
+}

--- a/src/main/java/com/artwork/mvc/view/ControlPanel.java
+++ b/src/main/java/com/artwork/mvc/view/ControlPanel.java
@@ -2,6 +2,7 @@ package com.artwork.mvc.view;
 
 import com.artwork.mvc.model.DrawingModel;
 import com.artwork.mvc.view.DrawingPanel;
+import com.artwork.mvc.view.ColorIcon;
 
 import javax.swing.*;
 import java.awt.*;
@@ -20,9 +21,10 @@ public class ControlPanel extends JPanel {
 
         for (int i = 0; i < COLORS.length; i++) {
             Color color = COLORS[i];
-            JButton btn = new JButton();
+            JButton btn = new JButton(new ColorIcon(color, 16));
             btn.setPreferredSize(new Dimension(20, 20));
             btn.setBackground(color);
+            btn.setOpaque(true);
             btn.setBorderPainted(false);
             btn.setFocusPainted(false);
             final int idx = i;
@@ -68,7 +70,8 @@ public class ControlPanel extends JPanel {
     private void updateButtonColors(DrawingModel model) {
         for (int i = 0; i < COLORS.length; i++) {
             Color base = COLORS[i];
-            colorButtons[i].setBackground(model.isDarkMode() ? DrawingModel.complementColor(base) : base);
+            Color toUse = model.isDarkMode() ? DrawingModel.complementColor(base) : base;
+            colorButtons[i].setBackground(toUse);
         }
     }
 }

--- a/src/main/java/com/artwork/mvc/view/MainFrame.java
+++ b/src/main/java/com/artwork/mvc/view/MainFrame.java
@@ -20,7 +20,8 @@ public class MainFrame extends JFrame {
 
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, controlPanel, drawingPanel);
         splitPane.setResizeWeight(0);
-        splitPane.setDividerLocation(150);
+        // give roughly one third of the width to the control panel
+        splitPane.setDividerLocation(0.33);
 
         getContentPane().setLayout(new BorderLayout());
         add(splitPane, BorderLayout.CENTER);


### PR DESCRIPTION
## Summary
- show color swatches with a new `ColorIcon` helper
- update `ControlPanel` to use icons and opaque buttons
- set split pane to roughly 1:2 panel-to-canvas ratio

## Testing
- `mvn -q -DskipTests=true package` *(fails: plugin could not be resolved)*
- `mvn -q test` *(fails: plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6881e284bafc8325b488312c20854c0e